### PR TITLE
Skip split apks when possible

### DIFF
--- a/.github/workflows/CIbuild.yml
+++ b/.github/workflows/CIbuild.yml
@@ -125,9 +125,9 @@ jobs:
           path: |
             patch-loader/build/symbols
             
-     # 成功构建后花生到频道
+     # 成功构建后发送到TG频道
       - name: Post to channel
-        if: github.event_name == 'push' && success() && github.ref == 'refs/heads/master'
+        if: ${{ github.event_name != 'pull_request' && success() && github.ref == 'refs/heads/master' }} && false
         env:
           CHANNEL_ID: ${{ secrets.CHANNEL_ID }}
           DISCUSSION_ID: ${{ secrets.DISCUSSION_ID }}

--- a/patch-loader/src/main/java/org/lsposed/lspatch/loader/LSPApplication.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/loader/LSPApplication.java
@@ -208,10 +208,6 @@ public class LSPApplication {
             File curProfileFile = new File(profileDir, splitName == null ? "primary.prof" : splitName + ".split.prof").getAbsoluteFile();
             Log.d(TAG, "Processing " + curProfileFile.getAbsolutePath());
             try {
-                if (!curProfileFile.exists()) {
-                    Files.createFile(curProfileFile.toPath(), attrs);
-                    continue;
-                }
                 if (!curProfileFile.canWrite() && Files.size(curProfileFile.toPath()) == 0) {
                     Log.d(TAG, "Skip profile " + curProfileFile.getAbsolutePath());
                     continue;
@@ -223,6 +219,8 @@ public class LSPApplication {
                         Log.e(TAG, "Failed to delete and clear profile file " + curProfileFile.getAbsolutePath(), e);
                     }
                     Os.chmod(curProfileFile.getAbsolutePath(), 00400);
+                } else {
+                    Files.createFile(curProfileFile.toPath(), attrs);
                 }
             } catch (Throwable e) {
                 Log.e(TAG, "Failed to disable profile file " + curProfileFile.getAbsolutePath(), e);

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -232,6 +232,18 @@ public class LSPatch {
                 logger.d("original minSdkVersion: " + minSdkVersion);
             }
 
+	            final boolean skipSplit = apkPaths.size() > 1 && srcApkFile.getName().startsWith("split_") && appComponentFactory == null;
+            if (skipSplit) {
+                logger.i("Packing split apk...");
+                for (StoredEntry entry : srcZFile.entries()) {
+                    String name = entry.getCentralDirectoryHeader().getName();
+                    if (dstZFile.get(name) != null) continue;
+                    if (name.startsWith("META-INF") && (name.endsWith(".SF") || name.endsWith(".MF") || name.endsWith(".RSA"))) continue;
+                    srcZFile.addFileLink(name, name);
+                }
+                return;
+            }
+
 
             logger.i("Patching apk...");
             // modify manifest


### PR DESCRIPTION
当appComponentFactory加载拆分的apks时，跳过修补以减少文件大小。